### PR TITLE
Fixing paths inside package

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ envsubst < /credentials.tmpl > ~/.aws/credentials
 
 HOME_DIR=$(pwd)
 pushd ${SOURCE_DIR}
-zip -r "${HOME_DIR}/${GITHUB_SHA}.zip" .\
+zip -r "${HOME_DIR}/${GITHUB_SHA}.zip" .
 popd
 
 if [ -z "$BUCKET" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,10 @@ envsubst < /config.tmpl > ~/.config/yandex-cloud/config.yaml
 
 envsubst < /credentials.tmpl > ~/.aws/credentials
 
-zip -r ${GITHUB_SHA}.zip ${SOURCE_DIR}
+HOME_DIR=$(pwd)
+pushd ${SOURCE_DIR}
+zip -r "${HOME_DIR}/${GITHUB_SHA}.zip" .\
+popd
 
 if [ -z "$BUCKET" ]; then
   if [ -z "$ENVIRONMENT" ]; then


### PR DESCRIPTION
The fix allows do not include the whole `SOURCE_DIR` path into the package.
It's useful, for instance, when you want to include `package.json` file in the root of the package,